### PR TITLE
.whatever, .kanyeshrug, handle long .ud responses and join note for atomies

### DIFF
--- a/commands/definer.js
+++ b/commands/definer.js
@@ -21,7 +21,10 @@ exports.init = function () {
                     if (_.isEmpty(results)) {
                         otterbot.chatSingle(_.template("Urban Dictionary doesn't play that '<%= search %>' shit", {'search': string}));
                     } else {
-                        otterbot.chatSingle("DEFINITION: " + results[0]["definition"]);
+                        var chunks = ("DEFINITION: " + de).replace(/(\r\n|\n|\r)/gm," ").match(/.{1,256}/g);
+                        for(var i=0; i<chunks.length; i++) {
+                            otterbot.chatSingle(chunks[i]);
+                        }
                     }
                 } else {
                     otterbot.log('Couldn\'t get a definition:');

--- a/commands/userjoin.js
+++ b/commands/userjoin.js
@@ -40,6 +40,10 @@ exports.init = function () {
                 message = 'Welcome J:shirt::m::o2:'
                 break;
 
+            case 'Atomies':
+                message = 'Hola Atom-mami http://i.imgur.com/4hh4P2O.png'
+                break;
+
             case 'otterbot':
                 message = 'otterbot in the heeeeeeezy'
                 break;

--- a/responses.js
+++ b/responses.js
@@ -691,4 +691,15 @@ module.exports = [
         response: 'http://i.imgur.com/nv8ylec.png?clear_it_image',
         match: 'exact'
     },
+    {
+        trigger: ['.we', '.whatever', '.idunno', '.dunno', '.shrug'],
+        response: '¯\\_(ツ)_/¯',
+        match: 'exact'
+    },
+    {
+        trigger: '.kanyeshrug',
+        response: 'http://i.imgur.com/vYgPmI8.gif',
+        match: 'exact'
+    },
+
 ];


### PR DESCRIPTION
Please check the long .ud handling (try `.ud butt`)

Also check .whatever. Previously it broke otterbot, presumably the backslash in the string. I've escaped it but ¯\_(ツ)_/¯